### PR TITLE
Fix code quality issues: usage strings, docs, and buffer handling

### DIFF
--- a/cmd/gip/commands.go
+++ b/cmd/gip/commands.go
@@ -28,7 +28,7 @@ var parallelFlags = []cli.Flag{
 var commandStatus = cli.Command{
 	Name:        "status",
 	Aliases:     []string{"s"},
-	Usage:       "",
+	Usage:       "show modified files in projects",
 	Description: `Prints modified files.`,
 	Action:      doStatus,
 	Flags:       parallelFlags,
@@ -37,7 +37,7 @@ var commandStatus = cli.Command{
 var commandStatusFull = cli.Command{
 	Name:        "statusfull",
 	Aliases:     []string{"sf"},
-	Usage:       "",
+	Usage:       "show modified and new files in projects",
 	Description: `Prints modified files and new ones.`,
 	Action:      doStatusFull,
 	Flags:       parallelFlags,
@@ -46,14 +46,14 @@ var commandStatusFull = cli.Command{
 var commandList = cli.Command{
 	Name:        "list",
 	Aliases:     []string{"ls"},
-	Usage:       "",
+	Usage:       "list registered projects",
 	Description: `List projects`,
 	Action:      doList,
 }
 
 var commandPull = cli.Command{
 	Name:        "pull",
-	Usage:       "",
+	Usage:       "update projects from remote repositories",
 	Description: `Pull projects`,
 	Action:      doPull,
 	Flags: append(parallelFlags,

--- a/cmd/gip/main.go
+++ b/cmd/gip/main.go
@@ -1,7 +1,8 @@
 package main
 
 /*
->go run main.go commands.go version.go utils.go statusfull
+>go run main.go commands.go utils.go statusfull
+Version info is imported from github.com/enr/gip/lib/core
 */
 
 import (

--- a/lib/core/git.go
+++ b/lib/core/git.go
@@ -40,7 +40,7 @@ func (g *GitCommands) Clone(ctx context.Context, repourl string, dirpath string)
 		return fmt.Errorf("invalid dirpath: cannot start with '-'")
 	}
 	g.ui.Confidentialf("Cloning %s to %s", repourl, dirpath)
-	err = os.MkdirAll(dirpath, 0755)
+	err = os.MkdirAll(dirpath, 0o755)
 	if err != nil {
 		g.ui.Errorf("Error preparing for clone path %s:", dirpath)
 		g.ui.Errorf("%v", err)

--- a/lib/core/git_test.go
+++ b/lib/core/git_test.go
@@ -15,7 +15,7 @@ type mockGitWrapper struct {
 
 func (m *mockGitWrapper) exec(r runcmdWrapperRequest) runcmdResult {
 	m.requests = append(m.requests, r)
-	return runcmdStubResult{success: true}
+	return &runcmdStubResult{success: true}
 }
 
 func TestGitCommands_Clone(t *testing.T) {

--- a/lib/core/runcmd_test.go
+++ b/lib/core/runcmd_test.go
@@ -14,7 +14,7 @@ type testGitWrapper struct {
 }
 
 func (g testGitWrapper) exec(r runcmdWrapperRequest) runcmdResult {
-	return runcmdStubResult{
+	return &runcmdStubResult{
 		stdout:     `stdout`,
 		stderr:     `stderr`,
 		success:    false,

--- a/lib/core/stubs_test.go
+++ b/lib/core/stubs_test.go
@@ -10,27 +10,31 @@ type runcmdStubResult struct {
 	stderr     string
 	err        error
 	exitStatus int
+	stdoutBuf  *bytes.Buffer
+	stderrBuf  *bytes.Buffer
 }
 
-func (r runcmdStubResult) Success() bool {
+func (r *runcmdStubResult) Success() bool {
 	return r.success
 }
-func (r runcmdStubResult) Stderr() *bytes.Buffer {
-	var b bytes.Buffer
-	b.WriteString(r.stderr)
-	return &b
+func (r *runcmdStubResult) Stderr() *bytes.Buffer {
+	if r.stderrBuf == nil {
+		r.stderrBuf = bytes.NewBufferString(r.stderr)
+	}
+	return r.stderrBuf
 }
 
 // Stdout returns the underlying buffer with the contents of the output stream.
-func (r runcmdStubResult) Stdout() *bytes.Buffer {
-	var b bytes.Buffer
-	b.WriteString(r.stdout)
-	return &b
+func (r *runcmdStubResult) Stdout() *bytes.Buffer {
+	if r.stdoutBuf == nil {
+		r.stdoutBuf = bytes.NewBufferString(r.stdout)
+	}
+	return r.stdoutBuf
 }
 
-func (r runcmdStubResult) Error() error {
+func (r *runcmdStubResult) Error() error {
 	return r.err
 }
-func (r runcmdStubResult) ExitStatus() int {
+func (r *runcmdStubResult) ExitStatus() int {
 	return r.exitStatus
 }


### PR DESCRIPTION
- L2: Add one-liner Usage strings to all commands (status, statusfull, list, pull)
- L4: Update stale doc comment in main.go referencing non-existent version.go file
- L5: Fix runcmdStubResult to cache buffers instead of allocating fresh ones per call
- L6: Use octal notation 0o755 instead of magic number 0755

Ensures consistent behavior with production implementations and improves code clarity.

https://claude.ai/code/session_017DHVqTuyQi1n6Lf1jmmc5D