### PR TITLE
Only colorize summary stats when counts are non-zero

### DIFF
--- a/cmd/gip/tracker.go
+++ b/cmd/gip/tracker.go
@@ -201,9 +201,9 @@ func (t *tracker) printSummary(errorsLast bool) {
 	}
 
 	elapsed := time.Since(t.started)
-	okStr := t.color(ansiGreen, fmt.Sprintf("OK: %d", okCount))
-	errStr := t.color(ansiRed, fmt.Sprintf("Errors: %d", errCount))
-	skipStr := t.color(ansiYellow, fmt.Sprintf("Skipped: %d", skipCount))
+	okStr := t.colorIf(okCount > 0, ansiGreen, fmt.Sprintf("OK: %d", okCount))
+	errStr := t.colorIf(errCount > 0, ansiRed, fmt.Sprintf("Errors: %d", errCount))
+	skipStr := t.colorIf(skipCount > 0, ansiYellow, fmt.Sprintf("Skipped: %d", skipCount))
 	fmt.Fprintf(os.Stdout, "─────────────────────────────────────────\n")
 	fmt.Fprintf(os.Stdout, "%s   %s   %s   Duration: %.1fs\n", okStr, errStr, skipStr, elapsed.Seconds())
 	if noopMode {
@@ -280,6 +280,13 @@ func (t *tracker) color(code, text string) string {
 		return text
 	}
 	return code + text + ansiReset
+}
+
+func (t *tracker) colorIf(cond bool, code, text string) string {
+	if !cond {
+		return text
+	}
+	return t.color(code, text)
 }
 
 func isTTY(f *os.File) bool {


### PR DESCRIPTION
## Summary

Refactor the summary output formatting to conditionally apply ANSI color codes only when the corresponding count is greater than zero. This improves readability by avoiding unnecessary color codes for zero-valued statistics.

## Changes

- **New helper method `colorIf`**: Added `colorIf(cond bool, code, text string)` to the `tracker` struct that applies color only when a condition is true; otherwise returns plain text.
- **Updated summary formatting**: Changed `printSummary` to use `colorIf` for OK, Errors, and Skipped counts, applying color only when each count is non-zero.

## Implementation Details

The new `colorIf` method follows the existing `color` method pattern and integrates seamlessly with the current ANSI color output system. This change is purely cosmetic and affects only the text summary output (not JSON mode), making the summary line cleaner when certain categories have no results.

https://claude.ai/code/session_01FGw8BYjRYcc1damYxWE8S7