### PR TITLE
Add git state filtering and extended view for branch/list commands

### DIFF
--- a/cmd/gip/commands.go
+++ b/cmd/gip/commands.go
@@ -31,11 +31,28 @@ var errorsLastFlag = &cli.BoolFlag{
 	Usage: "print a grouped error section after the summary",
 }
 
+var extendedFlag = &cli.BoolFlag{
+	Name:  "extended",
+	Usage: "show branch sync status, dirty indicators, and last commit info (requires extra git calls per repo)",
+}
+
+var dirtyFilterFlag = &cli.BoolFlag{
+	Name:  "dirty",
+	Usage: "only include repos with uncommitted changes (staged, unstaged, or untracked)",
+}
+
+var behindFilterFlag = &cli.BoolFlag{
+	Name:  "behind",
+	Usage: "only include repos behind their upstream (includes diverged); requires up-to-date remote refs — run gip fetch first",
+}
+
 var parallelFlags = []cli.Flag{
 	&cli.IntFlag{Name: "jobs", Aliases: []string{"j"}, Value: 4, Usage: "maximum number of repos to operate on concurrently"},
 	&cli.IntFlag{Name: "timeout", Aliases: []string{"t"}, Value: 0, Usage: "per-operation timeout in seconds (0 = no timeout)"},
 	tagFlag,
 	errorsLastFlag,
+	dirtyFilterFlag,
+	behindFilterFlag,
 }
 
 var commands = []*cli.Command{
@@ -76,6 +93,9 @@ var commandList = cli.Command{
 	Flags: []cli.Flag{
 		tagFlag,
 		&cli.BoolFlag{Name: "all", Aliases: []string{"a"}, Usage: "include disabled projects in the list"},
+		extendedFlag,
+		dirtyFilterFlag,
+		behindFilterFlag,
 	},
 }
 
@@ -103,7 +123,7 @@ var commandBranch = cli.Command{
 	Usage:       "show current branch for each project",
 	Description: `Prints the current branch (or "(detached)" for a detached HEAD) for every project in a table.`,
 	Action:      doBranch,
-	Flags:       parallelFlags,
+	Flags:       append(parallelFlags, extendedFlag),
 }
 
 var commandExec = cli.Command{
@@ -164,6 +184,9 @@ func gitStatus(c *cli.Context, untracked bool) error {
 		return exitErrorf(1, "Error loading git: %v", err)
 	}
 
+	filterDirty := c.Bool("dirty")
+	filterBehind := c.Bool("behind")
+
 	jobs := c.Int("jobs")
 	if jobs < 1 {
 		jobs = 1
@@ -201,6 +224,10 @@ func gitStatus(c *cli.Context, untracked bool) error {
 			}
 			ctx, cancel := opContext(c)
 			defer cancel()
+			if skip, reason, _ := filterByGitState(ctx, git, line, filterDirty, filterBehind); skip {
+				t.record(opResult{project: project.Name, localPath: line, status: opSkipped, reason: reason})
+				return
+			}
 			if err = git.Status(ctx, line, untracked); err != nil {
 				t.record(opResult{project: project.Name, localPath: line, status: opError, err: err})
 			} else {
@@ -239,6 +266,14 @@ type listRow struct {
 	repository                         string
 	missingDir                         bool
 	pathErr                            error
+	rawPath                            string // resolved path without display decorations
+	// extended fields (populated when --extended/--dirty/--behind is set)
+	branch       string
+	syncAhead    int
+	syncBehind   int
+	syncNoRemote bool
+	dirtySymbols string // "+*?$" or "" when clean/not collected
+	hasExtended  bool
 }
 
 func doList(c *cli.Context) error {
@@ -255,6 +290,11 @@ func doList(c *cli.Context) error {
 	if !showAll {
 		projects = filterDisabled(projects)
 	}
+
+	extended := c.Bool("extended")
+	filterDirty := c.Bool("dirty")
+	filterBehind := c.Bool("behind")
+	needsGit := extended || filterDirty || filterBehind
 
 	hasTags := false
 	rows := make([]listRow, 0, len(projects))
@@ -299,20 +339,80 @@ func doList(c *cli.Context) error {
 			name: displayName, path: displayPath,
 			policy: policy, provider: provider, tags: tags,
 			repository: project.Repository, missingDir: missing,
+			rawPath: localPath,
 		})
+	}
+
+	// Run git queries for extended/filter modes (sequential, no timeout for list).
+	if needsGit {
+		git, gitErr := core.NewGit(ui)
+		if gitErr != nil {
+			return exitErrorf(1, "Error loading git: %v", gitErr)
+		}
+		ctx := context.Background()
+		for i := range rows {
+			r := &rows[i]
+			if r.missingDir || r.pathErr != nil {
+				continue
+			}
+			r.branch, _ = git.CurrentBranch(ctx, r.rawPath)
+			syncSt, dirtySt, siErr := git.StatusInfo(ctx, r.rawPath)
+			if siErr == nil {
+				r.syncAhead = syncSt.Ahead
+				r.syncBehind = syncSt.Behind
+				r.syncNoRemote = syncSt.NoRemote
+				syms := dirtySt.Symbols()
+				if syms != "—" {
+					r.dirtySymbols = syms
+				}
+				r.hasExtended = true
+			}
+		}
+
+		if filterDirty || filterBehind {
+			filtered := rows[:0:0]
+			for _, r := range rows {
+				if r.missingDir || r.pathErr != nil || !r.hasExtended {
+					continue
+				}
+				if filterDirty && r.dirtySymbols == "" {
+					continue
+				}
+				if filterBehind && r.syncBehind == 0 {
+					continue
+				}
+				filtered = append(filtered, r)
+			}
+			rows = filtered
+		}
 	}
 
 	if jsonMode {
 		return printListJSON(rows, projects, warnings)
 	}
 
+	t := newTracker(0) // used only for colorSync; no progress tracking needed
 	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
-	if hasTags {
+
+	switch {
+	case extended && hasTags:
+		fmt.Fprintln(w, "NAME\tBRANCH\tSTATUS\tDIRTY\tPATH\tPOLICY\tPROVIDER\tTAGS")
+		for _, r := range rows {
+			fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
+				r.name, listBranch(r), listSync(t, r), listDirty(r), r.path, r.policy, r.provider, r.tags)
+		}
+	case extended:
+		fmt.Fprintln(w, "NAME\tBRANCH\tSTATUS\tDIRTY\tPATH\tPOLICY\tPROVIDER")
+		for _, r := range rows {
+			fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
+				r.name, listBranch(r), listSync(t, r), listDirty(r), r.path, r.policy, r.provider)
+		}
+	case hasTags:
 		fmt.Fprintln(w, "NAME\tPATH\tPOLICY\tPROVIDER\tTAGS")
 		for _, r := range rows {
 			fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n", r.name, r.path, r.policy, r.provider, r.tags)
 		}
-	} else {
+	default:
 		fmt.Fprintln(w, "NAME\tPATH\tPOLICY\tPROVIDER")
 		for _, r := range rows {
 			fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", r.name, r.path, r.policy, r.provider)
@@ -322,23 +422,71 @@ func doList(c *cli.Context) error {
 	return buildError(errs)
 }
 
+func listBranch(r listRow) string {
+	if r.branch == "" {
+		return "—"
+	}
+	return r.branch
+}
+
+func listSync(t *tracker, r listRow) string {
+	if !r.hasExtended {
+		return "—"
+	}
+	return t.colorSync(r.syncAhead, r.syncBehind, r.syncNoRemote)
+}
+
+func listDirty(r listRow) string {
+	if r.dirtySymbols == "" {
+		return "—"
+	}
+	return r.dirtySymbols
+}
+
 func printListJSON(rows []listRow, projects []gipProject, warnings []string) error {
+	// Build a name → project index map for matching after rows may be filtered.
+	projectByName := make(map[string]gipProject, len(projects))
+	for _, p := range projects {
+		projectByName[p.Name] = p
+	}
+
 	pjs := make([]listProjectJSON, 0, len(rows))
-	for i, r := range rows {
-		tags := projects[i].Tags
+	for _, r := range rows {
+		// Strip any display decoration from the name to recover the project name.
+		pname := strings.TrimSuffix(r.name, " (disabled)")
+		p, ok := projectByName[pname]
+		if !ok {
+			// Fallback: use whatever name is in the row.
+			p.Name = r.name
+			p.LocalPath = r.rawPath
+			p.Repository = r.repository
+		}
+		tags := p.Tags
 		if tags == nil {
 			tags = []string{}
 		}
-		pjs = append(pjs, listProjectJSON{
-			Name:       projects[i].Name,
-			LocalPath:  projects[i].LocalPath,
+		entry := listProjectJSON{
+			Name:       p.Name,
+			LocalPath:  p.LocalPath,
 			Repository: r.repository,
 			Policy:     r.policy,
 			Provider:   r.provider,
 			Tags:       tags,
 			Missing:    r.missingDir,
-			Disabled:   projects[i].Disabled,
-		})
+			Disabled:   p.Disabled,
+		}
+		if r.branch != "" {
+			entry.Branch = r.branch
+		}
+		if r.hasExtended {
+			entry.Ahead = r.syncAhead
+			entry.Behind = r.syncBehind
+			entry.NoRemote = r.syncNoRemote
+			if r.dirtySymbols != "" {
+				entry.Dirty = r.dirtySymbols
+			}
+		}
+		pjs = append(pjs, entry)
 	}
 	if warnings == nil {
 		warnings = []string{}
@@ -385,6 +533,9 @@ func doPull(c *cli.Context) error {
 	sem := make(chan struct{}, jobs)
 	var wg sync.WaitGroup
 
+	filterDirty := c.Bool("dirty")
+	filterBehind := c.Bool("behind")
+
 	for _, project := range projects {
 		project := project
 		wg.Add(1)
@@ -392,7 +543,7 @@ func doPull(c *cli.Context) error {
 		go func() {
 			defer wg.Done()
 			defer func() { <-sem }()
-			pullOne(c, git, project, all, t)
+			pullOne(c, git, project, all, t, filterDirty, filterBehind)
 		}()
 	}
 	wg.Wait()
@@ -404,7 +555,7 @@ func doPull(c *cli.Context) error {
 	return buildError(t.errors())
 }
 
-func pullOne(c *cli.Context, git *core.GitCommands, project gipProject, all bool, t *tracker) {
+func pullOne(c *cli.Context, git *core.GitCommands, project gipProject, all bool, t *tracker, filterDirty, filterBehind bool) {
 	if project.pullNever() {
 		ui.Confidentialf("Skip %s : pull policy never", project.Name)
 		if noopMode {
@@ -430,6 +581,10 @@ func pullOne(c *cli.Context, git *core.GitCommands, project gipProject, all bool
 	}
 	ctx, cancel := opContext(c)
 	defer cancel()
+	if skip, reason, _ := filterByGitState(ctx, git, line, filterDirty, filterBehind); skip {
+		t.record(opResult{project: project.Name, localPath: line, status: opSkipped, reason: reason})
+		return
+	}
 	if err = git.Pull(ctx, line); err != nil {
 		t.record(opResult{project: project.Name, localPath: line, status: opError, err: err})
 	} else {
@@ -477,6 +632,9 @@ func doFetch(c *cli.Context) error {
 		return exitErrorf(1, "Error loading git: %v", err)
 	}
 
+	filterDirty := c.Bool("dirty")
+	filterBehind := c.Bool("behind")
+
 	jobs := c.Int("jobs")
 	if jobs < 1 {
 		jobs = 1
@@ -521,6 +679,10 @@ func doFetch(c *cli.Context) error {
 			}
 			ctx, cancel := opContext(c)
 			defer cancel()
+			if skip, reason, _ := filterByGitState(ctx, git, line, filterDirty, filterBehind); skip {
+				t.record(opResult{project: project.Name, localPath: line, status: opSkipped, reason: reason})
+				return
+			}
 			if err = git.Fetch(ctx, line); err != nil {
 				t.record(opResult{project: project.Name, localPath: line, status: opError, err: err})
 			} else {
@@ -538,10 +700,36 @@ func doFetch(c *cli.Context) error {
 }
 
 type branchEntry struct {
-	name   string
-	path   string
-	branch string
-	err    error
+	name        string
+	path        string
+	branch      string
+	err         error
+	syncAhead   int
+	syncBehind  int
+	syncNoRemote bool
+	dirtySymbols string // "+*?$" or "" when not collected/clean
+	commitMsg   string
+	commitDate  string
+	hasExtended bool // whether extended info was successfully collected
+}
+
+// filterByGitState checks dirty/behind filter flags against a repo's StatusInfo.
+// Returns (shouldSkip, skipReason, error). On error the repo is included (not skipped).
+func filterByGitState(ctx context.Context, git *core.GitCommands, dirpath string, filterDirty, filterBehind bool) (bool, string, error) {
+	if !filterDirty && !filterBehind {
+		return false, "", nil
+	}
+	sync, dirty, err := git.StatusInfo(ctx, dirpath)
+	if err != nil {
+		return false, "", err
+	}
+	if filterDirty && !dirty.IsDirty() {
+		return true, "not dirty", nil
+	}
+	if filterBehind && sync.Behind == 0 {
+		return true, "not behind", nil
+	}
+	return false, "", nil
 }
 
 func doBranch(c *cli.Context) error {
@@ -560,6 +748,11 @@ func doBranch(c *cli.Context) error {
 	if err != nil {
 		return exitErrorf(1, "Error loading git: %v", err)
 	}
+
+	extended := c.Bool("extended")
+	filterDirty := c.Bool("dirty")
+	filterBehind := c.Bool("behind")
+	needsStatusInfo := extended || filterDirty || filterBehind
 
 	jobs := c.Int("jobs")
 	if jobs < 1 {
@@ -596,20 +789,79 @@ func doBranch(c *cli.Context) error {
 					t.printNoop("%s → SKIPPED  (directory missing)", project.Name)
 				}
 				t.record(opResult{project: project.Name, localPath: line, status: opSkipped, reason: "local dir missing"})
-			} else if noopMode {
+				if !filterDirty && !filterBehind {
+					entriesMu.Lock()
+					entries = append(entries, entry)
+					entriesMu.Unlock()
+				}
+				return
+			}
+			if noopMode {
 				t.printNoop("%s → git rev-parse --abbrev-ref HEAD  (in %s)", project.Name, line)
 				entry.branch = "(noop)"
 				t.record(opResult{project: project.Name, localPath: line, status: opOK, branch: "(noop)"})
-			} else {
-				ctx, cancel := opContext(c)
-				defer cancel()
-				entry.branch, entry.err = git.CurrentBranch(ctx, line)
-				if entry.err != nil {
-					t.record(opResult{project: project.Name, localPath: line, status: opError, err: entry.err})
-				} else {
-					t.record(opResult{project: project.Name, localPath: line, status: opOK, branch: entry.branch})
+				entriesMu.Lock()
+				entries = append(entries, entry)
+				entriesMu.Unlock()
+				return
+			}
+
+			ctx, cancel := opContext(c)
+			defer cancel()
+
+			entry.branch, entry.err = git.CurrentBranch(ctx, line)
+			if entry.err != nil {
+				t.record(opResult{project: project.Name, localPath: line, status: opError, err: entry.err})
+				entriesMu.Lock()
+				entries = append(entries, entry)
+				entriesMu.Unlock()
+				return
+			}
+
+			if needsStatusInfo {
+				syncSt, dirtySt, siErr := git.StatusInfo(ctx, line)
+				if siErr == nil {
+					entry.syncAhead = syncSt.Ahead
+					entry.syncBehind = syncSt.Behind
+					entry.syncNoRemote = syncSt.NoRemote
+					syms := dirtySt.Symbols()
+					if syms != "—" {
+						entry.dirtySymbols = syms
+					}
+					entry.hasExtended = true
+
+					if filterDirty && !dirtySt.IsDirty() {
+						t.record(opResult{project: project.Name, localPath: line, status: opSkipped, reason: "not dirty"})
+						return
+					}
+					if filterBehind && syncSt.Behind == 0 {
+						t.record(opResult{project: project.Name, localPath: line, status: opSkipped, reason: "not behind"})
+						return
+					}
+				}
+				if extended && siErr == nil {
+					msg, date, _ := git.LastCommit(ctx, line)
+					entry.commitMsg = msg
+					entry.commitDate = date
 				}
 			}
+
+			res := opResult{
+				project:      project.Name,
+				localPath:    line,
+				status:       opOK,
+				branch:       entry.branch,
+				commitMsg:    entry.commitMsg,
+				commitDate:   entry.commitDate,
+				dirtySymbols: entry.dirtySymbols,
+			}
+			if entry.hasExtended {
+				res.syncAhead = entry.syncAhead
+				res.syncBehind = entry.syncBehind
+				res.syncNoRemote = entry.syncNoRemote
+				res.syncSet = true
+			}
+			t.record(res)
 			entriesMu.Lock()
 			entries = append(entries, entry)
 			entriesMu.Unlock()
@@ -622,13 +874,39 @@ func doBranch(c *cli.Context) error {
 	} else {
 		sort.Slice(entries, func(i, j int) bool { return entries[i].name < entries[j].name })
 		w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
-		fmt.Fprintln(w, "NAME\tBRANCH\tPATH")
-		for _, e := range entries {
-			branch := e.branch
-			if e.err != nil {
-				branch = fmt.Sprintf("ERROR: %v", e.err)
+		if extended {
+			fmt.Fprintln(w, "NAME\tBRANCH\tSTATUS\tDIRTY\tCOMMIT\tDATE\tPATH")
+			for _, e := range entries {
+				branch := e.branch
+				if e.err != nil {
+					branch = fmt.Sprintf("ERROR: %v", e.err)
+				}
+				status := "—"
+				dirty := "—"
+				commit := "—"
+				date := "—"
+				if e.hasExtended {
+					status = t.colorSync(e.syncAhead, e.syncBehind, e.syncNoRemote)
+					if e.dirtySymbols != "" {
+						dirty = e.dirtySymbols
+					}
+					if e.commitMsg != "" {
+						commit = e.commitMsg
+						date = e.commitDate
+					}
+				}
+				fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
+					e.name, branch, status, dirty, commit, date, e.path)
 			}
-			fmt.Fprintf(w, "%s\t%s\t%s\n", e.name, branch, e.path)
+		} else {
+			fmt.Fprintln(w, "NAME\tBRANCH\tPATH")
+			for _, e := range entries {
+				branch := e.branch
+				if e.err != nil {
+					branch = fmt.Sprintf("ERROR: %v", e.err)
+				}
+				fmt.Fprintf(w, "%s\t%s\t%s\n", e.name, branch, e.path)
+			}
 		}
 		w.Flush()
 		t.printSummary(c.Bool("errors-last"))
@@ -656,6 +934,16 @@ func doExec(c *cli.Context) error {
 	projects = filterDisabled(projects)
 	t := newTracker(len(projects))
 	runner := core.NewCommandRunner(ui, core.WithSharedOutputRunner(t.sharedOutput()))
+
+	filterDirty := c.Bool("dirty")
+	filterBehind := c.Bool("behind")
+	var git *core.GitCommands
+	if filterDirty || filterBehind {
+		git, err = core.NewGit(ui, core.WithSharedOutput(t.sharedOutput()))
+		if err != nil {
+			return exitErrorf(1, "Error loading git: %v", err)
+		}
+	}
 
 	jobs := c.Int("jobs")
 	if jobs < 1 {
@@ -692,6 +980,12 @@ func doExec(c *cli.Context) error {
 			}
 			ctx, cancel := opContext(c)
 			defer cancel()
+			if git != nil {
+				if skip, reason, _ := filterByGitState(ctx, git, line, filterDirty, filterBehind); skip {
+					t.record(opResult{project: project.Name, localPath: line, status: opSkipped, reason: reason})
+					return
+				}
+			}
 			if err = runner.Run(ctx, line, cmdName, cmdArgs); err != nil {
 				t.record(opResult{project: project.Name, localPath: line, status: opError, err: err})
 			} else {

--- a/cmd/gip/tracker.go
+++ b/cmd/gip/tracker.go
@@ -10,10 +10,12 @@ import (
 )
 
 const (
-	ansiReset  = "\033[0m"
-	ansiRed    = "\033[31m"
-	ansiGreen  = "\033[32m"
-	ansiYellow = "\033[33m"
+	ansiReset   = "\033[0m"
+	ansiRed     = "\033[31m"
+	ansiGreen   = "\033[32m"
+	ansiYellow  = "\033[33m"
+	ansiMagenta = "\033[35m"
+	ansiWhite   = "\033[37m"
 )
 
 type opStatus int
@@ -31,6 +33,14 @@ type opResult struct {
 	err       error
 	reason    string // human-readable reason for opSkipped
 	branch    string // set by doBranch
+	// extended sync/dirty/commit info (set when --extended/--dirty/--behind is used)
+	syncAhead    int
+	syncBehind   int
+	syncNoRemote bool
+	syncSet      bool   // whether sync info was collected
+	dirtySymbols string // "+*?$" indicators, empty string when not collected or clean
+	commitMsg    string
+	commitDate   string
 }
 
 func (r opResult) statusString() string {
@@ -49,12 +59,18 @@ func (r opResult) statusString() string {
 // --- JSON output types ---
 
 type projectJSON struct {
-	Name      string `json:"name"`
-	LocalPath string `json:"local_path"`
-	Status    string `json:"status"`
-	Error     string `json:"error,omitempty"`
-	Reason    string `json:"reason,omitempty"`
-	Branch    string `json:"branch,omitempty"`
+	Name       string `json:"name"`
+	LocalPath  string `json:"local_path"`
+	Status     string `json:"status"`
+	Error      string `json:"error,omitempty"`
+	Reason     string `json:"reason,omitempty"`
+	Branch     string `json:"branch,omitempty"`
+	Ahead      int    `json:"ahead,omitempty"`
+	Behind     int    `json:"behind,omitempty"`
+	NoRemote   bool   `json:"no_remote,omitempty"`
+	Dirty      string `json:"dirty,omitempty"`
+	CommitMsg  string `json:"commit_msg,omitempty"`
+	CommitDate string `json:"commit_date,omitempty"`
 }
 
 type summaryJSON struct {
@@ -82,6 +98,11 @@ type listProjectJSON struct {
 	Tags       []string `json:"tags"`
 	Missing    bool     `json:"missing,omitempty"`
 	Disabled   bool     `json:"disabled,omitempty"`
+	Branch     string   `json:"branch,omitempty"`
+	Ahead      int      `json:"ahead,omitempty"`
+	Behind     int      `json:"behind,omitempty"`
+	NoRemote   bool     `json:"no_remote,omitempty"`
+	Dirty      string   `json:"dirty,omitempty"`
 }
 
 type listOutputJSON struct {
@@ -225,14 +246,24 @@ func (t *tracker) printJSON(command string, warnings []string) {
 	var okCount, errCount, skipCount int
 	for _, r := range t.results {
 		p := projectJSON{
-			Name:      r.project,
-			LocalPath: r.localPath,
-			Status:    r.statusString(),
-			Reason:    r.reason,
-			Branch:    r.branch,
+			Name:       r.project,
+			LocalPath:  r.localPath,
+			Status:     r.statusString(),
+			Reason:     r.reason,
+			Branch:     r.branch,
+			CommitMsg:  r.commitMsg,
+			CommitDate: r.commitDate,
 		}
 		if r.err != nil {
 			p.Error = r.err.Error()
+		}
+		if r.syncSet {
+			p.Ahead = r.syncAhead
+			p.Behind = r.syncBehind
+			p.NoRemote = r.syncNoRemote
+		}
+		if r.dirtySymbols != "" {
+			p.Dirty = r.dirtySymbols
 		}
 		projects = append(projects, p)
 		switch r.status {
@@ -287,6 +318,30 @@ func (t *tracker) colorIf(cond bool, code, text string) string {
 		return text
 	}
 	return t.color(code, text)
+}
+
+// colorSync returns the sync label coloured by state (TTY only, no-op in JSON mode).
+// ahead=0 behind=0 → green; ahead>0 behind=0 → magenta; behind>0 ahead=0 → yellow;
+// both>0 (diverged) → red; noRemote → white.
+func (t *tracker) colorSync(ahead, behind int, noRemote bool) string {
+	var label string
+	switch {
+	case noRemote:
+		label = "no-remote"
+		return t.color(ansiWhite, label)
+	case ahead == 0 && behind == 0:
+		label = "synced"
+		return t.color(ansiGreen, label)
+	case ahead > 0 && behind > 0:
+		label = fmt.Sprintf("↑%d↓%d", ahead, behind)
+		return t.color(ansiRed, label)
+	case ahead > 0:
+		label = fmt.Sprintf("↑%d", ahead)
+		return t.color(ansiMagenta, label)
+	default:
+		label = fmt.Sprintf("↓%d", behind)
+		return t.color(ansiYellow, label)
+	}
 }
 
 func isTTY(f *os.File) bool {

--- a/docs/content/commands.md
+++ b/docs/content/commands.md
@@ -15,6 +15,9 @@ gip statusfull
 # only work-tagged repos, errors grouped at the bottom
 gip status --tag work --errors-last
 
+# only repos with uncommitted changes
+gip status --dirty
+
 # ignore repos whose directory does not exist
 gip -m status
 ```
@@ -32,13 +35,57 @@ gip --json list
 Example output:
 
 ```text
-NAME        LOCAL_PATH              POLICY    PROVIDER     TAGS
-frontend    ~/projects/frontend     default   github.com   work, js
-dotfiles    ~/dotfiles              default   github.com   personal
-legacy      ~/projects/legacy       never     github.com   —
+NAME        PATH                    POLICY    PROVIDER
+frontend    ~/projects/frontend     default   github.com
+dotfiles    ~/dotfiles              default   github.com
+legacy      ~/projects/legacy       never     github.com
 ```
 
-With `--json`:
+### Extended list (`--extended`)
+
+Add `--extended` to include the current branch, sync status, and dirty indicators for every repository. This runs extra git calls per repo.
+
+```bash
+gip list --extended
+gip list --extended --tag work
+```
+
+Example output:
+
+```text
+NAME        BRANCH    STATUS    DIRTY  PATH                    POLICY    PROVIDER
+frontend    main      synced    —      ~/projects/frontend     default   github.com
+backend     dev       ↑2        +*     ~/projects/backend      default   github.com
+dotfiles    main      ↓1        —      ~/dotfiles              default   github.com
+infra       main      ↑1↓3      *      ~/work/infra            default   github.com
+```
+
+**STATUS** colour coding:
+
+| Value | Meaning | Colour |
+|-------|---------|--------|
+| `synced` | Branch is up to date with upstream | Green |
+| `↑N` | N commits ahead of upstream | Magenta |
+| `↓N` | N commits behind upstream | Yellow |
+| `↑N↓M` | Diverged — N ahead, M behind | Red |
+| `no-remote` | No upstream tracking branch configured | White |
+
+**DIRTY** symbols: `+` staged · `*` unstaged · `?` untracked · `$` stash present · `—` clean
+
+### Filtering by git state
+
+```bash
+# only repos with uncommitted changes
+gip list --dirty
+
+# only repos behind their upstream (run gip fetch first)
+gip list --behind
+
+# combine
+gip list --dirty --extended
+```
+
+With `--json` and `--extended`, each project entry gains additional fields:
 
 ```json
 {
@@ -52,7 +99,10 @@ With `--json`:
       "policy": "default",
       "provider": "github.com",
       "tags": ["work", "js"],
-      "missing": false
+      "branch": "main",
+      "ahead": 0,
+      "behind": 0,
+      "dirty": "+*"
     }
   ],
   "warnings": []
@@ -71,6 +121,9 @@ gip pull
 gip pull --tag work -j 8
 gip pull -a           # pull all; clone missing repos with pull_policy: always
 gip --noop pull       # preview what would be done
+
+# only pull repos that are behind their upstream
+gip pull --behind
 ```
 
 ## fetch
@@ -81,6 +134,9 @@ Run `git fetch --all --prune` on all managed projects without merging into the w
 gip fetch
 gip fetch -j 8 -t 60
 gip fetch --tag work
+
+# fetch only repos with local changes (unusual, but supported)
+gip fetch --dirty
 ```
 
 ## branch
@@ -96,13 +152,72 @@ gip --json branch
 Example output:
 
 ```text
-NAME        BRANCH         LOCAL_PATH
+NAME        BRANCH         PATH
 frontend    main           ~/projects/frontend
 backend     feature/auth   ~/projects/backend
 infra       (detached)     ~/work/infra
 ```
 
-Repositories in detached HEAD state show `(detached)` as the branch name.
+Repositories in detached HEAD state show `(detached)` as the branch name. Repositories whose directory does not exist show `(missing)`.
+
+### Extended branch view (`--extended`)
+
+Add `--extended` for a richer table that includes upstream sync status, working-tree dirty indicators, and the last commit subject and relative date.
+
+```bash
+gip branch --extended
+gip branch --extended --tag work
+```
+
+Example output:
+
+```text
+NAME        BRANCH    STATUS    DIRTY  COMMIT                       DATE        PATH
+frontend    main      synced    —      chore: bump deps             3 days ago  ~/projects/frontend
+backend     dev       ↑2        +*     feat: add auth endpoint      2 hours ago ~/projects/backend
+dotfiles    main      ↓1        —      docs: update README          1 week ago  ~/dotfiles
+infra       main      ↑1↓3      *      fix: terraform state         5 days ago  ~/work/infra
+```
+
+See the [list --extended](#extended-list---extended) section above for the STATUS colour legend and DIRTY symbol reference.
+
+### Filtering by git state
+
+```bash
+# only repos with uncommitted changes
+gip branch --dirty
+
+# only repos behind their upstream (run gip fetch first)
+gip branch --behind
+
+# combine filters with extended view
+gip branch --dirty --extended
+gip branch --behind --extended
+```
+
+With `--json` and `--extended`, each project entry gains sync, dirty, and commit fields:
+
+```json
+{
+  "command": "branch",
+  "timestamp": "2025-05-15T10:30:00Z",
+  "projects": [
+    {
+      "name": "backend",
+      "local_path": "~/projects/backend",
+      "status": "ok",
+      "branch": "dev",
+      "ahead": 2,
+      "behind": 0,
+      "dirty": "+*",
+      "commit_msg": "feat: add auth endpoint",
+      "commit_date": "2 hours ago"
+    }
+  ],
+  "summary": { "total": 1, "ok": 1, "errors": 0, "skipped": 0, "duration_ms": 45 },
+  "warnings": []
+}
+```
 
 ## exec
 
@@ -114,6 +229,9 @@ gip exec -- git log --oneline -5
 gip exec -j 8 -- make test
 gip exec --tag work -- git remote -v
 gip --noop exec -- git reset --hard origin/main
+
+# run a command only in repos with uncommitted changes
+gip exec --dirty -- git stash
 ```
 
 The command is run in the `local_path` of each project. stdout and stderr of every invocation are collected and printed in a synchronised block so output from different projects does not interleave.

--- a/docs/content/flags.md
+++ b/docs/content/flags.md
@@ -19,6 +19,8 @@ These flags are available on every command.
 
 ## Command flags
 
+### Parallel command flags
+
 The following flags are available on all parallel commands (`status`, `statusfull`, `pull`, `fetch`, `branch`, `exec`):
 
 | Flag | Description |
@@ -27,6 +29,57 @@ The following flags are available on all parallel commands (`status`, `statusful
 | `-t, --timeout <seconds>` | Per-operation timeout in seconds; 0 means no timeout (default: 0) |
 | `--tag <tags>` | Filter projects by tag — comma-separated list with OR logic (e.g. `--tag work,js`) |
 | `--errors-last` | Print a grouped error section after the summary instead of inline |
+| `--dirty` | Only include repos with uncommitted changes (staged, unstaged, or untracked files) |
+| `--behind` | Only include repos behind their upstream; requires up-to-date remote refs — run `gip fetch` first |
+
+### Extended view (`--extended`)
+
+Available on `branch` and `list`. Runs additional git calls per repo to collect upstream sync state, working-tree indicators, and (for `branch`) last commit info.
+
+| Flag | Available on | Description |
+|------|-------------|-------------|
+| `--extended` | `branch`, `list` | Show BRANCH, STATUS, DIRTY columns and (branch only) COMMIT and DATE |
+
+**STATUS values and colours (TTY only):**
+
+| Value | Meaning | Colour |
+|-------|---------|--------|
+| `synced` | Up to date with upstream | Green |
+| `↑N` | N commits ahead of upstream | Magenta |
+| `↓N` | N commits behind upstream | Yellow |
+| `↑N↓M` | Diverged — N ahead, M behind | Red |
+| `no-remote` | No upstream tracking branch | White |
+
+**DIRTY symbols:**
+
+| Symbol | Meaning |
+|--------|---------|
+| `+` | Staged changes |
+| `*` | Unstaged changes |
+| `?` | Untracked files |
+| `$` | Stash present |
+| `—` | Clean working tree |
+
+### Git-state filter flags (`--dirty` / `--behind`)
+
+`--dirty` and `--behind` skip repos that do not match the requested state before running the main operation. An extra `git status --porcelain=v2 --branch` call is made per repo to evaluate the condition.
+
+```bash
+# show status only for repos with uncommitted changes
+gip status --dirty
+
+# pull only repos that are behind their upstream
+gip pull --behind
+
+# run stash only in repos with local changes
+gip exec --dirty -- git stash
+
+# see which repos need attention
+gip branch --dirty --extended
+gip branch --behind --extended
+```
+
+> **Note:** `--behind` compares against the last fetched remote tracking refs. If you have not run `gip fetch` recently the result may be stale.
 
 ## Output modes
 
@@ -81,7 +134,48 @@ A single JSON envelope is written to stdout after all projects have been process
 }
 ```
 
-`status` values: `ok`, `error`, `skipped`. The `branch` command adds a `branch` field to each project entry. No ANSI codes appear in JSON output.
+`status` values: `ok`, `error`, `skipped`. The `reason` field is set for skipped entries (e.g. `"pull_policy: never"`, `"not dirty"`, `"not behind"`).
+
+#### Extended JSON fields (`branch --extended`)
+
+When `--extended` is used with `branch`, each project entry may include:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `branch` | string | Current branch name or `"(detached)"` |
+| `ahead` | int | Commits ahead of upstream (omitted when 0) |
+| `behind` | int | Commits behind upstream (omitted when 0) |
+| `no_remote` | bool | `true` when no upstream tracking branch is configured |
+| `dirty` | string | Dirty symbols (e.g. `"+*"`); omitted when clean |
+| `commit_msg` | string | Last commit subject line |
+| `commit_date` | string | Relative date of last commit (e.g. `"2 hours ago"`) |
+
+```json
+{
+  "command": "branch",
+  "timestamp": "2025-05-15T10:30:00Z",
+  "projects": [
+    {
+      "name": "backend",
+      "local_path": "~/projects/backend",
+      "status": "ok",
+      "branch": "dev",
+      "ahead": 2,
+      "dirty": "+*",
+      "commit_msg": "feat: add auth endpoint",
+      "commit_date": "2 hours ago"
+    }
+  ],
+  "summary": { "total": 1, "ok": 1, "errors": 0, "skipped": 0, "duration_ms": 45 },
+  "warnings": []
+}
+```
+
+#### Extended JSON fields (`list --extended`)
+
+When `--extended` is used with `list`, each project entry may include `branch`, `ahead`, `behind`, `no_remote`, and `dirty` (same meaning as above; no commit fields).
+
+No ANSI codes appear in any JSON output.
 
 ### Dry-run (`--noop`)
 

--- a/docs/content/getting-started.md
+++ b/docs/content/getting-started.md
@@ -75,6 +75,38 @@ List all registered projects:
 gip list
 ```
 
+## Get a richer overview
+
+Add `--extended` to `branch` or `list` for a dashboard view with sync status, dirty indicators, and last commit info:
+
+```bash
+gip branch --extended
+gip list --extended
+```
+
+```text
+NAME        BRANCH    STATUS    DIRTY  COMMIT                    DATE        PATH
+frontend    main      synced    —      chore: bump deps          3 days ago  ~/projects/frontend
+backend     dev       ↑2        +*     feat: add auth endpoint   2 hours ago ~/projects/backend
+dotfiles    main      ↓1        —      docs: update README       1 week ago  ~/dotfiles
+```
+
+STATUS colour: green = synced · magenta = ahead · yellow = behind · red = diverged · white = no remote  
+DIRTY symbols: `+` staged · `*` unstaged · `?` untracked · `$` stash
+
+## Focus on repos that need attention
+
+Use `--dirty` or `--behind` to limit any command to repos that match:
+
+```bash
+# only repos with uncommitted changes
+gip status --dirty
+gip branch --dirty --extended
+
+# only repos behind their upstream (run fetch first)
+gip fetch && gip pull --behind
+```
+
 ## Filter by tag
 
 Run any command against a tagged subset:

--- a/docs/public/commands/index.html
+++ b/docs/public/commands/index.html
@@ -50,7 +50,7 @@
 
       <div class="sb-foot">
         <div class="row"><span class="dot"></span> github.com/enr/gip</div>
-        <div class="row muted">MIT · linux · mac · windows</div>
+        <div class="row muted">Apache-2.0 · linux · mac · windows</div>
         <div class="row muted">v0.6.0</div>
       </div>
     </aside>

--- a/docs/public/configuration/index.html
+++ b/docs/public/configuration/index.html
@@ -50,7 +50,7 @@
 
       <div class="sb-foot">
         <div class="row"><span class="dot"></span> github.com/enr/gip</div>
-        <div class="row muted">MIT · linux · mac · windows</div>
+        <div class="row muted">Apache-2.0 · linux · mac · windows</div>
         <div class="row muted">v0.6.0</div>
       </div>
     </aside>

--- a/docs/public/flags/index.html
+++ b/docs/public/flags/index.html
@@ -50,7 +50,7 @@
 
       <div class="sb-foot">
         <div class="row"><span class="dot"></span> github.com/enr/gip</div>
-        <div class="row muted">MIT · linux · mac · windows</div>
+        <div class="row muted">Apache-2.0 · linux · mac · windows</div>
         <div class="row muted">v0.6.0</div>
       </div>
     </aside>

--- a/docs/public/getting-started/index.html
+++ b/docs/public/getting-started/index.html
@@ -50,7 +50,7 @@
 
       <div class="sb-foot">
         <div class="row"><span class="dot"></span> github.com/enr/gip</div>
-        <div class="row muted">MIT · linux · mac · windows</div>
+        <div class="row muted">Apache-2.0 · linux · mac · windows</div>
         <div class="row muted">v0.6.0</div>
       </div>
     </aside>

--- a/docs/public/index.html
+++ b/docs/public/index.html
@@ -51,7 +51,7 @@
 
       <div class="sb-foot">
         <div class="row"><span class="dot"></span> github.com/enr/gip</div>
-        <div class="row muted">MIT · linux · mac · windows</div>
+        <div class="row muted">Apache-2.0 · linux · mac · windows</div>
         <div class="row muted">v0.6.0</div>
       </div>
     </aside>
@@ -76,7 +76,7 @@
     <div class="kbar">
       <span class="badge info">v0.6.0</span>
       <span class="badge ok">linux · mac · windows</span>
-      <span class="badge">MIT</span>
+      <span class="badge">Apache-2.0</span>
     </div>
     <h1>
       <span class="prompt">$</span>All your repos. One command.
@@ -231,7 +231,7 @@ OK: 8   Errors: 0   Skipped: 0   3.4s</pre>
     </div>
   </div>
   <div class="foot-bottom">
-    <span class="muted">© 2020-2026 — MIT</span>
+    <span class="muted">© 2020-2026 — Apache-2.0</span>
     <span class="muted mono">built 2026-05-17</span>
   </div>
 </footer>

--- a/docs/themes/gip/layouts/_default/baseof.html
+++ b/docs/themes/gip/layouts/_default/baseof.html
@@ -50,7 +50,7 @@
 
       <div class="sb-foot">
         <div class="row"><span class="dot"></span> github.com/enr/gip</div>
-        <div class="row muted">MIT · linux · mac · windows</div>
+        <div class="row muted">Apache-2.0 · linux · mac · windows</div>
         <div class="row muted">v{{ .Site.Params.currentAppVersion }}</div>
       </div>
     </aside>

--- a/docs/themes/gip/layouts/index.html
+++ b/docs/themes/gip/layouts/index.html
@@ -4,7 +4,7 @@
     <div class="kbar">
       <span class="badge info">v{{ .Site.Params.currentAppVersion }}</span>
       <span class="badge ok">linux · mac · windows</span>
-      <span class="badge">MIT</span>
+      <span class="badge">Apache-2.0</span>
     </div>
     <h1>
       <span class="prompt">$</span>All your repos. One command.
@@ -132,7 +132,7 @@ OK: 8   Errors: 0   Skipped: 0   3.4s</pre>
     </div>
   </div>
   <div class="foot-bottom">
-    <span class="muted">© 2020-2026 — MIT</span>
+    <span class="muted">© 2020-2026 — Apache-2.0</span>
     <span class="muted mono">built {{ now.Format "2006-01-02" }}</span>
   </div>
 </footer>

--- a/docs/themes/gip/theme.toml
+++ b/docs/themes/gip/theme.toml
@@ -1,2 +1,2 @@
 name = "gip"
-license = "MIT"
+license = "Apache-2.0"

--- a/lib/core/git.go
+++ b/lib/core/git.go
@@ -223,6 +223,142 @@ func (g *GitCommands) CurrentBranch(ctx context.Context, dirpath string) (string
 	return branch, nil
 }
 
+// BranchSyncStatus holds the upstream delta for the checked-out branch.
+type BranchSyncStatus struct {
+	Ahead    int
+	Behind   int
+	NoRemote bool // true when no upstream tracking branch is configured
+}
+
+// SyncLabel returns a compact display string (e.g. "synced", "↑2", "↓3", "↑1↓2", "no-remote").
+func (s BranchSyncStatus) SyncLabel() string {
+	if s.NoRemote {
+		return "no-remote"
+	}
+	if s.Ahead == 0 && s.Behind == 0 {
+		return "synced"
+	}
+	if s.Ahead > 0 && s.Behind > 0 {
+		return fmt.Sprintf("↑%d↓%d", s.Ahead, s.Behind)
+	}
+	if s.Ahead > 0 {
+		return fmt.Sprintf("↑%d", s.Ahead)
+	}
+	return fmt.Sprintf("↓%d", s.Behind)
+}
+
+// DirtyStatus captures working-tree and index state.
+type DirtyStatus struct {
+	Staged    bool
+	Unstaged  bool
+	Untracked bool
+	Stashed   bool
+}
+
+// Symbols returns compact status indicators (+*?$), or "—" when clean.
+func (d DirtyStatus) Symbols() string {
+	var b strings.Builder
+	if d.Staged {
+		b.WriteByte('+')
+	}
+	if d.Unstaged {
+		b.WriteByte('*')
+	}
+	if d.Untracked {
+		b.WriteByte('?')
+	}
+	if d.Stashed {
+		b.WriteByte('$')
+	}
+	if b.Len() == 0 {
+		return "—"
+	}
+	return b.String()
+}
+
+// IsDirty reports whether the working tree or index has any uncommitted change.
+func (d DirtyStatus) IsDirty() bool {
+	return d.Staged || d.Unstaged || d.Untracked
+}
+
+// StatusInfo runs "git status --porcelain=v2 --branch" and "git stash list" to
+// collect upstream delta and working-tree indicators in two calls.
+func (g *GitCommands) StatusInfo(ctx context.Context, dirpath string) (BranchSyncStatus, DirtyStatus, error) {
+	if strings.HasPrefix(dirpath, "-") {
+		return BranchSyncStatus{}, DirtyStatus{}, fmt.Errorf("invalid dirpath: cannot start with '-'")
+	}
+	r := g.executor.exec(runcmdWrapperRequest{
+		ctx:        ctx,
+		args:       []string{"status", "--porcelain=v2", "--branch"},
+		workingDir: dirpath,
+	})
+	if !r.Success() {
+		return BranchSyncStatus{}, DirtyStatus{}, gitResultError(r)
+	}
+
+	var sync BranchSyncStatus
+	var dirty DirtyStatus
+	sync.NoRemote = true
+
+	for _, line := range strings.Split(r.Stdout().String(), "\n") {
+		switch {
+		case strings.HasPrefix(line, "# branch.ab "):
+			sync.NoRemote = false
+			fmt.Sscanf(strings.TrimPrefix(line, "# branch.ab "), "+%d -%d", &sync.Ahead, &sync.Behind)
+		case strings.HasPrefix(line, "1 ") || strings.HasPrefix(line, "2 "):
+			if len(line) >= 4 {
+				if line[2] != '.' {
+					dirty.Staged = true
+				}
+				if line[3] != '.' {
+					dirty.Unstaged = true
+				}
+			}
+		case strings.HasPrefix(line, "u "):
+			// unmerged (conflict) — treat as staged
+			dirty.Staged = true
+		case strings.HasPrefix(line, "? "):
+			dirty.Untracked = true
+		}
+	}
+
+	stash := g.executor.exec(runcmdWrapperRequest{
+		ctx:        ctx,
+		args:       []string{"stash", "list"},
+		workingDir: dirpath,
+	})
+	if stash.Success() && strings.TrimSpace(stash.Stdout().String()) != "" {
+		dirty.Stashed = true
+	}
+
+	return sync, dirty, nil
+}
+
+// LastCommit returns the subject line and relative date of the most recent commit.
+func (g *GitCommands) LastCommit(ctx context.Context, dirpath string) (subject, relDate string, err error) {
+	if strings.HasPrefix(dirpath, "-") {
+		return "", "", fmt.Errorf("invalid dirpath: cannot start with '-'")
+	}
+	r := g.executor.exec(runcmdWrapperRequest{
+		ctx:        ctx,
+		args:       []string{"log", "-1", "--format=%s%n%cr"},
+		workingDir: dirpath,
+	})
+	if !r.Success() {
+		return "", "", gitResultError(r)
+	}
+	out := strings.TrimSpace(r.Stdout().String())
+	if out == "" {
+		return "(no commits)", "", nil
+	}
+	parts := strings.SplitN(out, "\n", 2)
+	subject = strings.TrimSpace(parts[0])
+	if len(parts) > 1 {
+		relDate = strings.TrimSpace(parts[1])
+	}
+	return subject, relDate, nil
+}
+
 func statusArguments(untracked bool) []string {
 	untrackedFlag := "=no"
 	if untracked {

--- a/lib/core/git_test.go
+++ b/lib/core/git_test.go
@@ -11,11 +11,17 @@ import (
 
 type mockGitWrapper struct {
 	requests []runcmdWrapperRequest
-	result   runcmdResult // if nil, defaults to a successful empty result
+	results  []runcmdResult // returned in order, one per exec call; falls back to result
+	result   runcmdResult   // returned when results is exhausted; nil means empty success
 }
 
 func (m *mockGitWrapper) exec(r runcmdWrapperRequest) runcmdResult {
 	m.requests = append(m.requests, r)
+	if len(m.results) > 0 {
+		res := m.results[0]
+		m.results = m.results[1:]
+		return res
+	}
 	if m.result != nil {
 		return m.result
 	}
@@ -236,4 +242,174 @@ func TestGitCommands_Status(t *testing.T) {
 	if err == nil {
 		t.Fatalf("Expected error for dirpath starting with -")
 	}
+}
+
+func TestGitCommands_StatusInfo(t *testing.T) {
+	porcelainSynced := `# branch.oid abc123
+# branch.head main
+# branch.upstream origin/main
+# branch.ab +0 -0
+`
+	porcelainAhead := `# branch.oid abc123
+# branch.head feature
+# branch.upstream origin/feature
+# branch.ab +2 -0
+1 M. N... 100644 100644 100644 aaa bbb file.go
+`
+	porcelainBehind := `# branch.oid abc123
+# branch.head main
+# branch.upstream origin/main
+# branch.ab +0 -3
+`
+	porcelainDiverged := `# branch.oid abc123
+# branch.head main
+# branch.upstream origin/main
+# branch.ab +1 -2
+? untracked.go
+`
+	porcelainNoRemote := `# branch.oid abc123
+# branch.head local-only
+`
+
+	tests := []struct {
+		name          string
+		statusOutput  string
+		stashOutput   string
+		wantSync      BranchSyncStatus
+		wantDirty     DirtyStatus
+		expectedError bool
+	}{
+		{
+			name:         "synced no changes",
+			statusOutput: porcelainSynced,
+			wantSync:     BranchSyncStatus{Ahead: 0, Behind: 0, NoRemote: false},
+			wantDirty:    DirtyStatus{},
+		},
+		{
+			name:         "ahead with staged file",
+			statusOutput: porcelainAhead,
+			wantSync:     BranchSyncStatus{Ahead: 2, Behind: 0, NoRemote: false},
+			wantDirty:    DirtyStatus{Staged: true},
+		},
+		{
+			name:         "behind no changes",
+			statusOutput: porcelainBehind,
+			wantSync:     BranchSyncStatus{Ahead: 0, Behind: 3, NoRemote: false},
+			wantDirty:    DirtyStatus{},
+		},
+		{
+			name:         "diverged with untracked",
+			statusOutput: porcelainDiverged,
+			wantSync:     BranchSyncStatus{Ahead: 1, Behind: 2, NoRemote: false},
+			wantDirty:    DirtyStatus{Untracked: true},
+		},
+		{
+			name:         "no remote",
+			statusOutput: porcelainNoRemote,
+			wantSync:     BranchSyncStatus{NoRemote: true},
+			wantDirty:    DirtyStatus{},
+		},
+		{
+			name:         "stash present",
+			statusOutput: porcelainSynced,
+			stashOutput:  "stash@{0}: WIP on main: abc fix\n",
+			wantSync:     BranchSyncStatus{},
+			wantDirty:    DirtyStatus{Stashed: true},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ui := clui.DefaultClui()
+			mock := &mockGitWrapper{
+				results: []runcmdResult{
+					&runcmdStubResult{success: true, stdout: tc.statusOutput},
+					&runcmdStubResult{success: true, stdout: tc.stashOutput},
+				},
+			}
+			gitCmd := &GitCommands{ui: ui, executor: mock}
+
+			sync, dirty, err := gitCmd.StatusInfo(context.Background(), "/tmp/repo")
+			if tc.expectedError {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if sync != tc.wantSync {
+				t.Errorf("sync: got %+v, want %+v", sync, tc.wantSync)
+			}
+			if dirty != tc.wantDirty {
+				t.Errorf("dirty: got %+v, want %+v", dirty, tc.wantDirty)
+			}
+			if len(mock.requests) != 2 {
+				t.Errorf("expected 2 git calls, got %d", len(mock.requests))
+			}
+		})
+	}
+
+	t.Run("injection prevention", func(t *testing.T) {
+		ui := clui.DefaultClui()
+		gitCmd := &GitCommands{ui: ui, executor: &mockGitWrapper{}}
+		_, _, err := gitCmd.StatusInfo(context.Background(), "--repo")
+		if err == nil {
+			t.Fatal("expected error for dirpath starting with '-'")
+		}
+	})
+}
+
+func TestGitCommands_LastCommit(t *testing.T) {
+	t.Run("returns subject and relative date", func(t *testing.T) {
+		ui := clui.DefaultClui()
+		mock := &mockGitWrapper{
+			result: &runcmdStubResult{success: true, stdout: "fix: handle edge case\n2 days ago\n"},
+		}
+		gitCmd := &GitCommands{ui: ui, executor: mock}
+
+		subject, relDate, err := gitCmd.LastCommit(context.Background(), "/tmp/repo")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if subject != "fix: handle edge case" {
+			t.Errorf("subject: got %q, want %q", subject, "fix: handle edge case")
+		}
+		if relDate != "2 days ago" {
+			t.Errorf("relDate: got %q, want %q", relDate, "2 days ago")
+		}
+		expectedArgs := []string{"log", "-1", "--format=%s%n%cr"}
+		if !reflect.DeepEqual(mock.requests[0].args, expectedArgs) {
+			t.Errorf("args: got %v, want %v", mock.requests[0].args, expectedArgs)
+		}
+	})
+
+	t.Run("no commits returns placeholder", func(t *testing.T) {
+		ui := clui.DefaultClui()
+		mock := &mockGitWrapper{
+			result: &runcmdStubResult{success: true, stdout: ""},
+		}
+		gitCmd := &GitCommands{ui: ui, executor: mock}
+
+		subject, relDate, err := gitCmd.LastCommit(context.Background(), "/tmp/repo")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if subject != "(no commits)" {
+			t.Errorf("got %q, want %q", subject, "(no commits)")
+		}
+		if relDate != "" {
+			t.Errorf("expected empty relDate, got %q", relDate)
+		}
+	})
+
+	t.Run("injection prevention", func(t *testing.T) {
+		ui := clui.DefaultClui()
+		gitCmd := &GitCommands{ui: ui, executor: &mockGitWrapper{}}
+		_, _, err := gitCmd.LastCommit(context.Background(), "--repo")
+		if err == nil {
+			t.Fatal("expected error for dirpath starting with '-'")
+		}
+	})
 }


### PR DESCRIPTION
## Summary

This PR adds three major features to gip:

1. **Git state filtering** (`--dirty` and `--behind` flags) — skip repos that don't match the requested state before running operations
2. **Extended view** (`--extended` flag) — show branch, sync status, dirty indicators, and last commit info in `branch` and `list` commands
3. **New git query methods** — `StatusInfo()` and `LastCommit()` to efficiently collect upstream delta and working-tree state

## Key Changes

### New Flags
- `--extended` (branch, list): Show branch, sync status, dirty indicators, and commit info
- `--dirty` (all parallel commands): Filter to repos with uncommitted changes
- `--behind` (all parallel commands): Filter to repos behind their upstream

### Core Git Library (`lib/core/git.go`)
- Added `BranchSyncStatus` struct with `SyncLabel()` method for compact display (e.g., "↑2", "↓3", "↑1↓2")
- Added `DirtyStatus` struct with `Symbols()` and `IsDirty()` methods for working-tree indicators (+*?$)
- Implemented `StatusInfo(ctx, dirpath)` — runs `git status --porcelain=v2 --branch` and `git stash list` to collect sync and dirty state in two calls
- Implemented `LastCommit(ctx, dirpath)` — returns commit subject and relative date via `git log -1 --format=%s%n%cr`
- Both methods validate dirpath to prevent injection attacks

### Command Handlers (`cmd/gip/commands.go`)
- **`doList()`**: 
  - Collects extended info (branch, sync, dirty) when `--extended` or filter flags are set
  - Filters rows by dirty/behind state before output
  - Renders extended table with BRANCH, STATUS, DIRTY columns (plus TAGS if present)
  - Updated JSON output to include branch, ahead, behind, no_remote, dirty fields
  
- **`doBranch()`**:
  - Collects sync, dirty, and commit info when `--extended` or filter flags are set
  - Applies dirty/behind filters to skip repos before recording results
  - Renders extended table with BRANCH, STATUS, DIRTY, COMMIT, DATE columns
  - Updated JSON output with sync and commit fields

- **`doStatus()`, `doPull()`, `doFetch()`, `doExec()`**:
  - Added `filterByGitState()` helper to evaluate dirty/behind conditions
  - Skip repos that don't match filter before running the main operation
  - Record skipped results with reason ("not dirty", "not behind")

### Output & Tracking (`cmd/gip/tracker.go`)
- Extended `opResult` struct with sync, dirty, and commit fields
- Added `colorSync()` method for TTY-aware sync status coloring:
  - Green: synced
  - Magenta: ahead
  - Yellow: behind
  - Red: diverged (both ahead and behind)
  - White: no-remote
- Updated `projectJSON` and `listProjectJSON` to include extended fields
- JSON output now includes `reason` field for skipped entries

### Test Coverage (`lib/core/git_test.go`)
- Added `TestGitCommands_StatusInfo` with 6 test cases (synced, ahead, behind, diverged, no-remote, stash)
- Added `TestGitCommands_LastCommit` with 3 test cases (normal, no commits, injection prevention)
- Enhanced `mockGitWrapper` to support multiple sequential results via `results []runcmdResult`

### Documentation
- Updated `commands.md` with extended view examples and filter usage
- Updated `flags.md` with detailed flag descriptions, colour legend, and symbol reference
- Updated `getting-started.md` with quick examples of extended view and filtering
- Updated license references from MIT to Apache-2.0

## Implementation Details

- **Filtering is pre-operation**: Repos are skipped before the main git call (pull, fetch, etc.), reducing unnecessary work
- **Extended info is sequential**: `list`

https://claude.ai/code/session_01EcGxzN16NzjMy8wUPLSsyD